### PR TITLE
Change conf/schema path; support some ENVs; merge instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,6 @@ demo/reg.log
 demo/registrator
 go.sum
 main
-reg.log
+**/log
+**/*.log
+conf/**/schema

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o registrator .
 
 FROM alpine:latest
 WORKDIR /opt/registrator
+ENV CHASSIS_CONF_DIR=/etc/registrator/conf \
+    SCHEMA_ROOT=/etc/registrator/schema
 COPY --from=builder /go/src/github.com/go-mesh/registrator/registrator .
-ENV CHASSIS_CONF_DIR /etc/registrator/
-ENTRYPOINT ["/opt/registrator/registrator", "-c", "/etc/registrator/reg.yaml"]
+COPY ./conf/*.yaml $CHASSIS_CONF_DIR/
+RUN mkdir -p $SCHEMA_ROOT
+ENTRYPOINT ["/opt/registrator/registrator", "-c", "/etc/registrator/conf/reg.yaml"]

--- a/README.md
+++ b/README.md
@@ -16,17 +16,13 @@ source:
   address: http://127.0.0.1:30100
   fetchInterval: 60s #how long to fetch services and instances and register them to target registry,
                   #if your instances is not changing rapidly, you can set it to longer
-  exclude: SERVICECENTER,CseConfigCenter,REGISTRATOR
+  exclude: SERVICECENTER,CseConfigCenter,CseMonitoring,REGISTRATOR
 target:
   address: http://127.0.0.1:30200
   heartbeatInterval: 30s # how long to send heart beat to target registry
-auth:
-  accessKey:
-  secretKey:
-  project:
 ```
 
 3. Run, CSE_REGISTRY_ADDR must equal to address of source
 ```bash
-docker run -e CSE_REGISTRY_ADDR=http://127.0.0.1:30100 -v /path/to/conf_folder:/etc/registrator/ -p 8080:8080 gomesh/registrator 
+docker run -v /path/to/conf_folder/:/etc/registrator/conf/ -p 8080:8080 gomesh/registrator 
 ```

--- a/conf/auth.yaml
+++ b/conf/auth.yaml
@@ -1,0 +1,6 @@
+---
+cse:
+  credentials:
+    accessKey:
+    secretKey:
+    project:

--- a/conf/chassis.yaml
+++ b/conf/chassis.yaml
@@ -1,0 +1,9 @@
+---
+cse:
+  service:
+    registry:
+      address: https://cse.cn-north-1.myhuaweicloud.com
+      disabled: true
+  protocols:
+    rest:
+      listenAddress: 0.0.0.0:8080

--- a/conf/microservice.yaml
+++ b/conf/microservice.yaml
@@ -1,0 +1,5 @@
+---
+#微服务的私有属性
+service_description:
+  name: REGISTRATOR
+  version: 0.1

--- a/conf/reg.yaml
+++ b/conf/reg.yaml
@@ -1,0 +1,7 @@
+source:
+  address: http://127.0.0.1:30100
+  fetchInterval: 120s # interval to fetch service/instance and register them to target registry
+  exclude: SERVICECENTER,CseConfigCenter,CseMonitoring,REGISTRATOR
+target:
+  address: http://127.0.0.1:30100
+  heartbeatInterval: 30s # how long to send heartbeat to target registry

--- a/config/config.go
+++ b/config/config.go
@@ -1,36 +1,21 @@
 package config
 
 import (
+	"io/ioutil"
+	"os"
+
 	"github.com/go-mesh/registrator/cmd"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
+)
+
+const (
+	SourceAddressEnv     = "SOURCE_ADDRESS"
+	TargetAddressEnv     = "TARGET_ADDRESS"
+	FetchIntervalEnv     = "FETCH_INTERVAL"
+	HeartbeatIntervalEnv = "HEARTBEAT_INTERVAL"
 )
 
 var Config = &Configuration{}
-
-type Configuration struct {
-	Source Source `yaml:"source"`
-	Target Target `yaml:"target"`
-	Auth   Auth   `yaml:"auth"`
-}
-
-type Source struct {
-	Address       string `yaml:"address"`
-	Auth          Auth   `yaml:"auth"`    //TODO register between tenants
-	Exclude       string `yaml:"exclude"` // service names, separated by commas
-	FetchInterval string `yaml:"fetchInterval"`
-}
-type Target struct {
-	Address           string `yaml:"address"`
-	Auth              Auth   `yaml:"auth"` //TODO register between tenants
-	HeartbeatInterval string `yaml:"heartbeatInterval"`
-}
-
-type Auth struct {
-	AK      string `yaml:"accessKey"`
-	SK      string `yaml:"secretKey"`
-	Project string `yaml:"project"`
-}
 
 func Init() error {
 	b, err := ioutil.ReadFile(cmd.CLIParam.ConfPath)
@@ -40,13 +25,25 @@ func Init() error {
 	if err := yaml.Unmarshal(b, Config); err != nil {
 		return err
 	}
+	if v := os.Getenv(SourceAddressEnv); v != "" {
+		Config.Source.Address = v
+	}
+	if v := os.Getenv(FetchIntervalEnv); v != "" {
+		Config.Source.FetchInterval = v
+	}
+	if v := os.Getenv(TargetAddressEnv); v != "" {
+		Config.Target.Address = v
+	}
+	if v := os.Getenv(HeartbeatIntervalEnv); v != "" {
+		Config.Target.HeartbeatInterval = v
+	}
 	setDefaultValue()
 	return nil
 }
 
 func setDefaultValue() {
 	if Config.Source.FetchInterval == "" {
-		Config.Source.FetchInterval = "60s"
+		Config.Source.FetchInterval = "120s"
 	}
 	if Config.Target.HeartbeatInterval == "" {
 		Config.Target.HeartbeatInterval = "30s"

--- a/config/type.go
+++ b/config/type.go
@@ -1,0 +1,25 @@
+package config
+
+type Configuration struct {
+	Source Source `yaml:"source"`
+	Target Target `yaml:"target"`
+	Auth   Auth   `yaml:"auth"`
+}
+
+type Source struct {
+	Address       string `yaml:"address"`
+	Auth          Auth   `yaml:"auth"`    //TODO register between tenants
+	Exclude       string `yaml:"exclude"` // service names, separated by commas
+	FetchInterval string `yaml:"fetchInterval"`
+}
+type Target struct {
+	Address           string `yaml:"address"`
+	Auth              Auth   `yaml:"auth"` //TODO register between tenants
+	HeartbeatInterval string `yaml:"heartbeatInterval"`
+}
+
+type Auth struct {
+	AK      string `yaml:"accessKey"`
+	SK      string `yaml:"secretKey"`
+	Project string `yaml:"project"`
+}

--- a/reg/cache.go
+++ b/reg/cache.go
@@ -5,17 +5,30 @@ import (
 	"github.com/patrickmn/go-cache"
 )
 
+const instanceKey = "instance"
+
 var serviceCache = cache.New(0, 0)
 
+// SaveInstances merges new instances to old ones, not remove any old instance
 func SaveInstances(s map[string][]*proto.MicroServiceInstance) {
-	serviceCache.Set("instances", s, 0)
-
+	oldInstances := GetInstances()
+	if oldInstances == nil {
+		serviceCache.Set(instanceKey, s, 0)
+		return
+	}
+	result := make(map[string][]*proto.MicroServiceInstance, len(oldInstances))
+	for k, v := range oldInstances {
+		result[k] = v
+	}
+	for k, v := range s {
+		result[k] = v
+	}
+	serviceCache.Set(instanceKey, result, 0)
 }
 func GetInstances() map[string][]*proto.MicroServiceInstance {
-	s, ok := serviceCache.Get("instances")
+	s, ok := serviceCache.Get(instanceKey)
 	if !ok {
 		return nil
 	}
 	return s.(map[string][]*proto.MicroServiceInstance)
-
 }


### PR DESCRIPTION
- Change conf/schema path
The conf dir may be readonly if user mount files on it, so we must set schema dir to be different from conf dir.
- support some ENVs
To make it easy to deploy this tool.

- merge instances instead of reset